### PR TITLE
Tests: introduce HS compat test with TOR client

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,20 +6,36 @@ jobs:
   build_and_test:
     name: Build & Test
     runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - dotnet_version: "3.1.x"
+            flag: ""
+          - dotnet_version: "7.0.x"
+            flag: "-p:NET7=true"
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Setup .NET Core SDK 3.1.x
+      - name: Setup .NET SDK ${{ matrix.dotnet_version }}
         uses: actions/setup-dotnet@v1.7.2
         with:
-          dotnet-version: '3.1.x'
+          dotnet-version: ${{ matrix.dotnet_version }}
       - name: Install dependencies
-        run: dotnet restore
+        run: dotnet restore ${{ matrix.flag }}
       - name: Build
-        run: dotnet build --configuration Release --no-restore
+        run: dotnet build --configuration Release --no-restore ${{ matrix.flag }}
+      # Please keep in mind that NOnion DOES NOT require tor client to function
+      # tor client is only installed here for testing purposes.
+      - name: Install Tor and wait for startup
+        run: |
+          sudo apt install tor
+          echo -e "SOCKSPort 127.0.0.1:9050" | sudo tee -a /etc/tor/torrc
+          sudo systemctl restart tor
+          sleep 2m
       - name: Test
-        run: dotnet test --no-restore --verbosity normal
+        run: dotnet test --no-restore --verbosity normal ${{ matrix.flag }}
 
   sanity_check:
     name: Sanity Check

--- a/NOnion.Tests/NOnion.Tests.csproj
+++ b/NOnion.Tests/NOnion.Tests.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-
+    <TargetFramework Condition="'$(NET7)' != 'true'">netcoreapp3.1</TargetFramework>
+    <TargetFramework Condition="'$(NET7)' == 'true'">net7.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.10" />
   </ItemGroup>


### PR DESCRIPTION
This commit introduces a test to make sure our
hidden service hosts are accessible by official
tor client.

Testing only with NOnion's TorServiceClient can
cause mask problems because it shares lots of
code with TorServiceHost (especially crypto stuff) and mistakes there can go unnoticed.

Upgrade to .NET 6 was necessary to be able
to use SocksV5 (which is what tor gives us)
as proxy for HttpClient.

Due to some problem with NUnit not writing test-by-test output (whether it passed or failed), I had to upgrade even furthur into .NET 7.

NUnit was also updated to latest version because it was causing issue where some unrelated tests would fail in .NET7 (maybe the Retry attributed wasn't working).