### PR TITLE
NOnion: use tor official mirror

### DIFF
--- a/NOnion.Tests/FallbackDirectorySelector.cs
+++ b/NOnion.Tests/FallbackDirectorySelector.cs
@@ -14,7 +14,7 @@ namespace NOnion.Tests
         {
             if (fallbackDirectories == null)
             {
-                var urlToTorServerList = "https://raw.githubusercontent.com/torproject/tor/main/src/app/config/fallback_dirs.inc";
+                var urlToTorServerList = "https://gitlab.torproject.org/tpo/core/tor/-/raw/main/src/app/config/fallback_dirs.inc";
                 using var webClient = new WebClient();
                 var fetchedInfo = webClient.DownloadString(urlToTorServerList);
 

--- a/NOnion.Tests/HiddenServicesTests.cs
+++ b/NOnion.Tests/HiddenServicesTests.cs
@@ -51,7 +51,7 @@ namespace NOnion.Tests
 
         private async Task CreateIntroductionCircuit()
         {
-            using TorClient torClient = await TorClient.BootstrapWithGithubAsync(cachePath);
+            using TorClient torClient = await TorClient.BootstrapWithGitlabAsync(cachePath);
             var circuit = await torClient.CreateCircuitAsync(1, CircuitPurpose.Unknown, FSharpOption<CircuitNodeDetail>.None);
             await circuit.RegisterAsIntroductionPointAsync(FSharpOption<AsymmetricCipherKeyPair>.None, StubCallback, DisconnectionCallback);
         }
@@ -76,7 +76,7 @@ namespace NOnion.Tests
             var array = new byte[Constants.RendezvousCookieLength];
             RandomNumberGenerator.Create().GetNonZeroBytes(array);
 
-            using TorClient torClient = await TorClient.BootstrapWithGithubAsync(cachePath);
+            using TorClient torClient = await TorClient.BootstrapWithGitlabAsync(cachePath);
             var circuit = await torClient.CreateCircuitAsync(2, CircuitPurpose.Unknown, FSharpOption<CircuitNodeDetail>.None);
             await circuit.RegisterAsRendezvousPointAsync(array);
         }
@@ -103,7 +103,7 @@ namespace NOnion.Tests
 
         public async Task BrowseFacebookOverHS()
         {
-            using TorClient torClient = await TorClient.BootstrapWithGithubAsync(cachePath);
+            using TorClient torClient = await TorClient.BootstrapWithGitlabAsync(cachePath);
 
             var serviceClient = await TorServiceClient.ConnectAsync(torClient, "facebookwkhpilnemxj7asaniu7vnjjbiltxjqhye3mhbshg7kx5tfyd.onion");
             var stream = await serviceClient.GetStreamAsync();
@@ -129,7 +129,7 @@ namespace NOnion.Tests
 
         public async Task BrowseFacebookOverHSWithTLS()
         {
-            using TorClient torClient = await TorClient.BootstrapWithGithubAsync(cachePath);
+            using TorClient torClient = await TorClient.BootstrapWithGitlabAsync(cachePath);
             
             var serviceClient = await TorServiceClient.ConnectAsync(torClient, "facebookwkhpilnemxj7asaniu7vnjjbiltxjqhye3mhbshg7kx5tfyd.onion:443");
             var stream = await serviceClient.GetStreamAsync();
@@ -159,7 +159,7 @@ namespace NOnion.Tests
 
         public async Task EstablishAndCommunicateOverHSConnectionOnionStyle()
         {
-            using TorClient torClient = await TorClient.BootstrapWithGithubAsync(cachePath);
+            using TorClient torClient = await TorClient.BootstrapWithGitlabAsync(cachePath);
             
             TorLogger.Log("Finished bootstraping");
 

--- a/NOnion.Tests/TorClientTests.cs
+++ b/NOnion.Tests/TorClientTests.cs
@@ -10,15 +10,15 @@ namespace NOnion.Tests
 {
     public class TorClientTests
     {
-        private async Task BootstrapWithGithub()
+        private async Task BootstrapWithGitlab()
         {
-            await TorClient.BootstrapWithGithubAsync(FSharpOption<DirectoryInfo>.None);
+            await TorClient.BootstrapWithGitlabAsync(FSharpOption<DirectoryInfo>.None);
         }
 
         [Test]
-        public void CanBootstrapWithGithub()
+        public void CanBootstrapWithGitlab()
         {
-            Assert.DoesNotThrowAsync(BootstrapWithGithub);
+            Assert.DoesNotThrowAsync(BootstrapWithGitlab);
         }
         
         private async Task BootstrapWithEmbeddedList()

--- a/NOnion/Client/TorClient.fs
+++ b/NOnion/Client/TorClient.fs
@@ -113,7 +113,7 @@ type TorClient internal (directory: TorDirectory) =
         =
         TorClient.AsyncBootstrapWithEmbeddedList cachePath |> Async.StartAsTask
 
-    static member AsyncBootstrapWithGithub(cachePath: Option<DirectoryInfo>) =
+    static member AsyncBootstrapWithGitlab(cachePath: Option<DirectoryInfo>) =
         async {
             // Don't put this inside the fallbackListString or it gets disposed
             // before the task gets executed
@@ -121,15 +121,15 @@ type TorClient internal (directory: TorDirectory) =
 
             let! fallbackListString =
                 let urlToTorServerList =
-                    "https://raw.githubusercontent.com/torproject/tor/main/src/app/config/fallback_dirs.inc"
+                    "https://gitlab.torproject.org/tpo/core/tor/-/raw/main/src/app/config/fallback_dirs.inc"
 
                 httpClient.GetStringAsync urlToTorServerList |> Async.AwaitTask
 
             return! CreateClientFromFallbackString fallbackListString cachePath
         }
 
-    static member BootstrapWithGithubAsync(cachePath: Option<DirectoryInfo>) =
-        TorClient.AsyncBootstrapWithGithub cachePath |> Async.StartAsTask
+    static member BootstrapWithGitlabAsync(cachePath: Option<DirectoryInfo>) =
+        TorClient.AsyncBootstrapWithGitlab cachePath |> Async.StartAsTask
 
     member __.Directory = directory
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Install via NuGet:
 To utilize the Tor network, start by bootstrapping your directory. This step involves downloading the most recent information about available routers and their identity keys.
 
 To initiate the bootstrapping process, you require a list of initial nodes for communication. In NOnion, there are two methods to obtain this list:
-1- [Download from Github](https://github.com/torproject/tor/blob/main/src/app/config/fallback_dirs.inc)
+1- [Download from GitLab](https://gitlab.torproject.org/tpo/core/tor/-/raw/main/src/app/config/fallback_dirs.inc)
 2- Utilize the embedded list in the NOnion binary (Note: this list could potentially be outdated)
 
 Based on what option you choose use one of the following commands to bootstrap a TorClient object:
@@ -41,7 +41,7 @@ let! torClient = TorClient.AsyncBootstrapWithEmbeddedList None
 ```
 ### OR
 ```
-let! torClient = TorClient.AsyncBootstrapWithGithub None
+let! torClient = TorClient.AsyncBootstrapWithGitlab None
 ```
 ## Browsing the web
 


### PR DESCRIPTION
Tor Github mirror has been removed, this commit changes the URLs to the official GitLab.

[1] https://github.com/torproject/tor/commi/27d4ba90f6dbf0c80d518a358b9600ae789509e4